### PR TITLE
Fix import casing for resultSet

### DIFF
--- a/copy-value-to-item-column/__tests__/cs_copyValueToItem.test.js
+++ b/copy-value-to-item-column/__tests__/cs_copyValueToItem.test.js
@@ -6,14 +6,14 @@ import CurrentRecord from 'N/currentRecord/instance'
 import search from 'N/search'
 import Search from 'N/search/instance'
 import Result from 'N/search/result'
-import ResultSet from 'N/search/resultset'
+import ResultSet from 'N/search/resultSet'
 
 jest.mock('N/currentRecord')
 jest.mock('N/currentRecord/instance')
 jest.mock('N/search')
 jest.mock('N/search/instance')
 jest.mock('N/search/result')
-jest.mock('N/search/resultset')
+jest.mock('N/search/resultSet')
 
 beforeEach(() => {
   jest.clearAllMocks()

--- a/salesorder-deposit-tracking/__tests__/ue_handle_deposit.test.js
+++ b/salesorder-deposit-tracking/__tests__/ue_handle_deposit.test.js
@@ -6,14 +6,14 @@ import Record from 'N/record/instance'
 
 import search from 'N/search'
 import Search from 'N/search/instance'
-import ResultSet from 'N/search/resultset'
+import ResultSet from 'N/search/resultSet'
 import Result from 'N/search/result'
 
 jest.mock('N/record')
 jest.mock('N/record/instance')
 jest.mock('N/search')
 jest.mock('N/search/instance')
-jest.mock('N/search/resultset')
+jest.mock('N/search/resultSet')
 jest.mock('N/search/result')
 
 beforeEach(() => {

--- a/salesorder-deposit-tracking/__tests__/ue_handle_refund.test.js
+++ b/salesorder-deposit-tracking/__tests__/ue_handle_refund.test.js
@@ -3,7 +3,7 @@ import script from '../src/FileCabinet/SuiteScripts/ue_handle_refund'
 
 import search from 'N/search'
 import Search from 'N/search/instance'
-import ResultSet from 'N/search/resultset'
+import ResultSet from 'N/search/resultSet'
 import Result from 'N/search/result'
 import record from 'N/record' 
 import Record from 'N/record/instance'
@@ -13,7 +13,7 @@ jest.mock('N/record/instance')
 jest.mock('N/search')
 jest.mock('N/search/instance')
 jest.mock('N/search/result')
-jest.mock('N/search/resultset')
+jest.mock('N/search/resultSet')
 
 beforeEach(() => {
   jest.clearAllMocks()

--- a/salesorder-deposit-tracking/__tests__/ue_set_custom_fields.test.js
+++ b/salesorder-deposit-tracking/__tests__/ue_set_custom_fields.test.js
@@ -6,14 +6,14 @@ import Record from 'N/record/instance'
 import search from 'N/search'
 import Search from 'N/search/instance'
 import Filter from 'N/search/filter'
-import ResultSet from 'N/search/resultset'
+import ResultSet from 'N/search/resultSet'
 import Result from 'N/search/result'
 
 jest.mock('N/record')
 jest.mock('N/record/instance')
 jest.mock('N/search')
 jest.mock('N/search/instance')
-jest.mock('N/search/resultset')
+jest.mock('N/search/resultSet')
 jest.mock('N/search/result')
 
 beforeEach(() => {

--- a/salesorder-deposit-tracking/__tests__/ue_update_custom_fields.test.js
+++ b/salesorder-deposit-tracking/__tests__/ue_update_custom_fields.test.js
@@ -6,7 +6,7 @@ import Record from 'N/record/instance'
 
 import search from 'N/search'
 import Search from 'N/search/instance'
-import ResultSet from 'N/search/resultset'
+import ResultSet from 'N/search/resultSet'
 import Result from 'N/search/result'
 import Filter from 'N/search/filter'
 
@@ -15,7 +15,7 @@ jest.mock('N/record/instance')
 jest.mock('N/search')
 jest.mock('N/search/instance')
 jest.mock('N/search/result')
-jest.mock('N/search/resultset')
+jest.mock('N/search/resultSet')
 
 beforeEach(() => {
   jest.clearAllMocks()

--- a/set-default-posting-period/__tests__/cs_preferredPostingPeriod.test.js
+++ b/set-default-posting-period/__tests__/cs_preferredPostingPeriod.test.js
@@ -5,7 +5,7 @@ import CurrentRecord from 'N/currentRecord/instance'
 import search from 'N/search'
 import Search from 'N/search/instance'
 import Result from 'N/search/result'
-import ResultSet from 'N/search/resultset'
+import ResultSet from 'N/search/resultSet'
 import log from 'N/log'
 
 beforeEach(() => {
@@ -17,7 +17,7 @@ jest.mock('N/currentRecord/instance')
 jest.mock('N/search')
 jest.mock('N/search/instance')
 jest.mock('N/search/result')
-jest.mock('N/search/resultset')
+jest.mock('N/search/resultSet')
 
 const context = {}
 


### PR DESCRIPTION
Tests for `copy-value-to-item-column`, `salesorder-deposit-tracking`, and `set-default-posting-period` fail due to an import casing issue in the test files. This commit resolves that issue and gets the tests passing.